### PR TITLE
App handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "serve": "concurrently --kill-others \"cd src && python main.py -d\" \"npm run startWeb\"",
         "startEel": "cd src && python main.py",
         "buildWeb": "cd src/web && npm run build",
-        "buildBin": "cd src/web && npm run build && cd .. && python3 -m eel main.py web/build --onefile --name Bolinho --icon ./web/public/favicon.ico",
+        "buildBin": "cd src/web && npm run build && cd .. && python -m eel main.py web/build --onefile --name Bolinho --icon ./web/public/favicon.ico",
         "installDep": "npm install && pip install -r requirements.txt && cd src/web && npm install",
         "test": "cd src/web && npm run test"
     },

--- a/src/bolinho_api/classes.py
+++ b/src/bolinho_api/classes.py
@@ -25,10 +25,9 @@ class Readings:
     This class gathers the machine readings such as position and load.
     """
 
-    def __init__(self, z_axis_pos=0, current_load=0, max_load=0, status=""):
+    def __init__(self, z_axis_pos=0, current_load=0, status=""):
         self.z_axis_pos = z_axis_pos
         self.current_load = current_load
-        self.max_load = max_load
         self.status = status
 
 

--- a/src/bolinho_api/classes.py
+++ b/src/bolinho_api/classes.py
@@ -25,7 +25,7 @@ class Readings:
     This class gathers the machine readings such as position and load.
     """
 
-    def __init__(self, z_axis_pos=0, current_load=0, status=""):
+    def __init__(self, z_axis_pos=0, current_load=0, status="Desconectado"):
         self.z_axis_pos = z_axis_pos
         self.current_load = current_load
         self.status = status

--- a/src/bolinho_api/core.py
+++ b/src/bolinho_api/core.py
@@ -17,7 +17,6 @@
 
 import eel
 from state_class import StateE
-from state_class import app_state
 
 
 class CoreAPI:
@@ -32,21 +31,17 @@ class CoreAPI:
     def go_to_experiment_page(self):
         """
         Asks the frontend to go to the experiment page.
-        Changes te state in the state machine
 
         Returns 1 if succeeded.
         """
-        app_state.change_state(StateE.RUNNING_EXPERIMENT)
         return eel.goToExperimentPageJS()()
 
     def go_to_home_page(self):
         """
         Asks the frontend to go to the home page.
-        Changes te state in the state machine
 
         Returns 1 if succeeded.
         """
-        app_state.change_state(StateE.INSPECTING)
         return eel.goToHomePageJS()()
 
     def show_connect_prompt(self):

--- a/src/bolinho_api/core.py
+++ b/src/bolinho_api/core.py
@@ -16,6 +16,8 @@
 # along with Bolinho.  If not, see <http://www.gnu.org/licenses/>.
 
 import eel
+from state_class import StateE
+from state_class import app_state
 
 
 class CoreAPI:
@@ -30,17 +32,21 @@ class CoreAPI:
     def go_to_experiment_page(self):
         """
         Asks the frontend to go to the experiment page.
+        Changes te state in the state machine
 
         Returns 1 if succeeded.
         """
+        app_state.change_state(StateE.RUNNING_EXPERIMENT)
         return eel.goToExperimentPageJS()()
 
     def go_to_home_page(self):
         """
         Asks the frontend to go to the home page.
+        Changes te state in the state machine
 
         Returns 1 if succeeded.
         """
+        app_state.change_state(StateE.INSPECTING)
         return eel.goToHomePageJS()()
 
     def show_connect_prompt(self):

--- a/src/bolinho_handler/app_handler.py
+++ b/src/bolinho_handler/app_handler.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2023 Hefestus
+# 
+# This file is part of Bolinho.
+# 
+# Bolinho is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Bolinho is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Bolinho.  If not, see <http://www.gnu.org/licenses/>.
+
+from granulado.core import Granulado
+import bolinho_api.experiment as b_experiment
+import bolinho_api.classes as b_classes
+import bolinho_api.core as b_core
+import eel
+from state_class import StateE
+from state_class import app_state
+
+
+
+
+class AppHandler:
+    """
+    Main class that handles all the app logic
+    """
+    def __init__(self):
+        self.gran = Granulado()
+
+    def process(self):
+        print(f"current state: {app_state.state}")
+        match app_state.state:
+            case StateE.INSPECTING:
+                self.__update_ui_readings()
+                eel.sleep(0.2) # 5 FPS refresh rate
+            case StateE.RUNNING_EXPERIMENT:
+                self.gran.loop()
+                self.__update_ui_readings()
+                b_core.core_api.refresh_data()
+
+
+    def __update_ui_readings(self):
+        """
+        Updates the UI with the latest readings
+        """
+        new_readings = b_classes.Readings(status="Desconectado")
+        if(self.gran.is_connected()):
+            [current_load, current_pos] = self.gran.get_readings()
+            new_readings.current_load = current_load
+            new_readings.z_axis_pos = current_pos
+            new_readings.status = "Conectado"
+
+        b_experiment.experiment_api.set_readings(new_readings)
+
+
+
+app = AppHandler()

--- a/src/exposed_core.py
+++ b/src/exposed_core.py
@@ -20,13 +20,13 @@ import os
 import serial
 import json
 import serial.tools.list_ports
-from time import time
 
 from bolinho_api.ui import ui_api
 from bolinho_api.core import core_api
 
 from granulado.core import Granulado
 from DBHandler import db_handler
+from app_handler import bolinho_app
 
 _CONFIG_PARAMS_PATH = "persist/configParams.json"
 
@@ -84,6 +84,7 @@ def start_experiment_routine(experiment_id: int):
     Returns 1 if succeeded.
     """
     core_api.go_to_experiment_page()
+    bolinho_app.start_experiment(experiment_id)
 
     return 1
     experiment = db_handler.get_experiment_by_id(experiment_id)
@@ -160,6 +161,8 @@ def end_experiment_routine():
 
     # TODO Add implementation
     core_api.go_to_home_page()
+    bolinho_app.end_experiment()
+
     return 1
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ from bolinho_api.experiment import experiment_api
 
 from granulado.core import Granulado
 from granulado import Messages
+from bolinho_handler import app_handler
 
 parser = ArgumentParser()
 parser.add_argument(
@@ -88,13 +89,10 @@ def main():
     wait_for_connection()
 
     # infinite loop so it doesn't close the socket
-    gran = Granulado()
     while True:
-        gran.loop()
+        app_handler.app.process()
         
-        # gran.sendSerialMessage(message=Messages.GET_BUFFER)
-    while True:
-        eel.sleep(1)
+
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -22,13 +22,9 @@ from argparse import ArgumentParser
 from bolinho_api.classes import Readings
 import expose_db, exposed_core  # não remover
 
-from bolinho_api.ui import ui_api
-from bolinho_api.core import core_api
-from bolinho_api.experiment import experiment_api
-
 from granulado.core import Granulado
 from granulado import Messages
-from bolinho_handler import app_handler
+from app_handler import bolinho_app
 
 parser = ArgumentParser()
 parser.add_argument(
@@ -69,16 +65,6 @@ def start_eel():
         raise
 
 
-def wait_for_connection():
-    """
-    Will stay in a infinite loop until connected to the front end
-    """
-    while True:
-        try:
-            if core_api.ping():
-                break
-        except:
-            eel.sleep(1)
 
 
 def main():
@@ -86,11 +72,11 @@ def main():
     eel.spawn(start_eel)  # Inicializando eel em outro thread
 
     # You can only use front end functions after the connection
-    wait_for_connection()
+    bolinho_app.wait_for_connection()
 
     # infinite loop so it doesn't close the socket
     while True:
-        app_handler.app.process()
+        bolinho_app.process()
         
 
 

--- a/src/state_class.py
+++ b/src/state_class.py
@@ -20,7 +20,7 @@ class StateE(Enum):
     """
     Possibles states of the state machine
     """
-    INSPECTING = 1
+    INSPECTING = 1 # For non critical states, allows the CPU to not be blocking at 100% usage 
     RUNNING_EXPERIMENT = 2
 
 class AppState:

--- a/src/state_class.py
+++ b/src/state_class.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2023 Hefestus
+# 
+# This file is part of Bolinho.
+# 
+# Bolinho is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# Bolinho is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Bolinho.  If not, see <http://www.gnu.org/licenses/>.
+from enum import Enum
+
+class StateE(Enum):
+    """
+    Possibles states of the state machine
+    """
+    INSPECTING = 1
+    RUNNING_EXPERIMENT = 2
+
+class AppState:
+    def __init__(self):
+        self.state: StateE = StateE.INSPECTING
+
+    def change_state(self, new_state:StateE):
+        """
+        Handle state transitions here
+        """
+        self.state = new_state
+
+app_state = AppState()

--- a/src/web/src/components/ReadingsContainer/ReadingsContainer.tsx
+++ b/src/web/src/components/ReadingsContainer/ReadingsContainer.tsx
@@ -50,10 +50,6 @@ const ReadingsContainer: FunctionComponent<ReadingsContainerProps> = ({
                     value={`${readingsContext.current_load} N`}
                 />
                 <CustomText
-                    title="Carga máxima"
-                    value={`${readingsContext.max_load} N`}
-                />
-                <CustomText
                     title="Status"
                     value={`${readingsContext.status}`}
                 />

--- a/src/web/src/types/ReadingsType.ts
+++ b/src/web/src/types/ReadingsType.ts
@@ -18,13 +18,11 @@
 export type ReadingsType = {
     z_axis_pos: number; // Position of the z-axis in mm
     current_load: number; // Load reading from the load cell in Newtons
-    max_load: number; // Load reading from the load cell in Newtons
     status: string; // Arbitrary status string
 };
 
 export const defaultReadingsType: ReadingsType = {
     z_axis_pos: 0,
     current_load: 0,
-    max_load: 0,
     status: "",
 };


### PR DESCRIPTION
This PR lays the foundation of the app handler, this class will handle the states and main loops of the App.

Added refreshing.


## To be defined
* The front end currently refreshes the data by calling the methods `get_load_over_position_by_experiment_id` and `get_load_over_time_by_experiment_id`, both of which fetches the data from the DB, we were going to keep the current experiment data on volatile memory until the end of the experiment, when it would be written to the disk, that will require a mod of these functions to return the current data on the app handler when an experiment is active.
* Will we write to the disk as we read or modify to fetch from the RAM?